### PR TITLE
parameter 'pool' allows attaching to a license pool after registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The module adds the following new types:
 - **password**: The password to use when registering the system
 - **server_hostname**: Specify a url to use as a server
 - **username**: The username to use when registering the system
+- **pool**: A specific license pool to attach the system to
 
 ### rhsm_register Examples
 
@@ -49,6 +50,16 @@ rhsm_register { 'subscription.rhn.example.com':
   password        => 'mypassword',
   autosubscribe   => true,
   force           => true,
+}
+</pre>
+
+Register clients to Red Hat Subscription management and attach to a specific license pool:
+
+<pre>
+rhsm_register { 'subscription.rhn.example.com':
+  username        => 'myusername',
+  password        => 'mypassword',
+  pool		  => 'mypoolid',
 }
 </pre>
 

--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -40,6 +40,15 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
     return params
   end
 
+  def build_attach_parameters
+    params = []
+
+    params << "attach"
+    params << "--pool" << @resource[:pool] if ! @resource[:pool].nil?
+
+    return params
+  end
+
   def config
     Puppet.debug("This server will be configered for rhsm")
     cmd = build_config_parameters
@@ -49,6 +58,12 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
   def register
     Puppet.debug("This server will be registered")
     cmd = build_register_parameters
+    subscription_manager(*cmd)
+  end
+
+  def attach
+    Puppet.debug("This server will be attached to a pool")
+    cmd = build_attach_parameters
     subscription_manager(*cmd)
   end
 
@@ -82,4 +97,16 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
     end
   end
 
+  def pool
+    Puppet.debug("Checking for subscription PoolID: #{resource[:pool]}")
+    subscriptions = subscription_manager('list','--consumed')
+    if subscriptions =~ /#{Regexp.escape(resource[:pool])}/
+      Puppet.debug("Pool found")
+      return resource[:pool]
+    end
+  end
+
+  def pool=(value)
+    attach
+  end
 end

--- a/lib/puppet/type/rhsm_register.rb
+++ b/lib/puppet/type/rhsm_register.rb
@@ -54,6 +54,10 @@ Puppet::Type.newtype(:rhsm_register) do
     desc "The activation key to use when registering the system (cannot be used with username and password)"
   end
 
+  newproperty(:pool) do
+    desc "The license pool to attach to after registering the system"
+  end
+
   newparam(:autosubscribe, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc "Automatically attach this system to compatible subscriptions."
     defaultto false


### PR DESCRIPTION
I had a need to specify a pool for my RHEL 7 systems, so I've added pool support, which calls 'subscription-manager attach'.

Thanks for creating a module to start from.
