### PR TITLE
Adding support for RedHat Subscription Manager repository subscriptions ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ Read Licence file for more information.
 * Gaël Chamoulaud (gchamoul at redhat dot com)
 * James Laska (jlaska at redhat dot com)
 
-## Type and Provider
+## Types and Providers
 
 The module adds the following new types:
 
 * `rhsm_register` for managing Red Hat Subscriptions
+* `rhsm_repo'     for managing Red Hat Repository Subscriptions
 
-### Parameters
+### rhsm_register Parameters
 
 - **activationkeys**: The activation key to use when registering the system (cannot be used with username and password)
 - **ensure**: Valid values are `present`, `absent`. Default value is `present`.
@@ -29,7 +30,7 @@ The module adds the following new types:
 - **server_hostname**: Specify a url to use as a server
 - **username**: The username to use when registering the system
 
-### Example
+### rhsm_register Examples
 
 Register clients to Red Hat Subscription Management using an activation key:
 
@@ -51,6 +52,26 @@ rhsm_register { 'subscription.rhn.example.com':
 }
 </pre>
 
+### rhsm_repo Parameters
+
+- **ensure**: Valid values are `present`, `absent`. Default value is `present`.
+- **name**: The name of the repo registration to add
+
+### rhsm_repo Examples
+
+Add a repo:
+
+<pre>
+rhsm_repo { 'rhel-7-server-optional-rpms': }
+</pre>
+
+Remove a repo:
+
+<pre>
+rhsm_repo { 'rhel-7-server-optional-rpms': 
+  ensure	  => 'absent',
+}
+</pre>
 
 ## Installing
 

--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -1,0 +1,49 @@
+Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
+  @doc = <<-EOS
+    This provider registers a software repository via RedHat subscription manager.
+  EOS
+
+  confine :osfamily => :redhat
+
+  commands :subscription_manager => "subscription-manager"
+
+  def create
+    subscription_manager('repos','--enable',@resource[:name])
+  end
+
+  def destroy
+    subscription_manager('repos','--disable',@resource[:name])
+  end
+
+  def self.instances
+    repo_file = '/var/lib/rhsm/cache/written_overrides.json'
+    repo_instances = Array.new
+    if File.exists?(repo_file)
+      repos = JSON.parse(File.open(repo_file).read)
+      repos.each do |key, values|
+	debug("Checking enabled for #{key}")
+       if repos[key]['enabled'] == '1'
+	  debug("#{key} enabled")
+	  repo_instances.push(new(:name => key, :ensure => :present))
+	end
+     end
+      return repo_instances
+    end
+  end
+
+  def self.prefetch(resources)
+    repos = instances
+    resources.keys.each do |name|
+      if provider = repos.find{ |repo| repo.name == name }
+        resources[name].provider = provider 
+      end
+    end
+  end
+
+  def exists?
+    debug("Verifying whether repo is enabled")
+
+    @property_hash[:ensure] == :present
+  end
+
+end

--- a/lib/puppet/type/rhsm_repo.rb
+++ b/lib/puppet/type/rhsm_repo.rb
@@ -1,0 +1,13 @@
+require 'puppet/property/boolean'
+require 'puppet/type'
+
+Puppet::Type.newtype(:rhsm_repo) do
+  @doc = ""
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The rhsm channel to subscribe to."
+  end
+
+end


### PR DESCRIPTION
...with rhsm_repo

Adds new type rhsm_repo.  Supports adding and removing. Syntax:

rhsm_repo { 'rhel-7-server-optional-rpms': ensure => present }
rhsm_repo { 'rhel-7-server-optional-rpms': ensure => absent }

Makes use of : /var/lib/rhsm/cache/written_overrides.json to enumerate existing regstered repos.  Not sure if this is the best way to do this, but it seemed less expensive than `subscription-manager repos-list`
