### PR TITLE
Add an organization parameter to the provider

### DIFF
--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -29,6 +29,7 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
     params << "--username" << @resource[:username] if ! @resource[:username].nil?
     params << "--password" << @resource[:password] if ! @resource[:password].nil?
     params << "--activationkey" <<  @resource[:activationkeys] if ! @resource[:activationkeys].nil?
+    params << "--org" << @resource[:organization] if ! @resource[:organization].nil?
     params << "--force" if @resource[:force]
     params << "--autosubscribe" if @resource[:autosubscribe]
 

--- a/lib/puppet/type/rhsm_register.rb
+++ b/lib/puppet/type/rhsm_register.rb
@@ -54,6 +54,10 @@ Puppet::Type.newtype(:rhsm_register) do
     desc "The activation key to use when registering the system (cannot be used with username and password)"
   end
 
+  newparam(:organization) do
+    desc "The organization to use when registering the system (required with an activation key)"
+  end
+
   newparam(:autosubscribe, :parent => Puppet::Property::Boolean) do
     desc "Automatically attach this system to compatible subscriptions."
     defaultto false


### PR DESCRIPTION
subscription-manager requires an organization (--org) to be specified when registering with an activation key. This commit adds one. 
