### PR TITLE
adds katello server support

### DIFF
--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -13,7 +13,9 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
     params = []
     params << "config"
     params << "--server.hostname" << @resource[:server_hostname] if ! @resource[:server_hostname].nil?
+    params << "--server.prefix" << @resource[:server_prefix] if ! @resource[:server_prefix].nil?
     params << ["--server.insecure", "1"] if @resource[:server_insecure]
+    params << "--rhsm.repo_ca_cert" << @resource[:rhsm_cacert] if ! @resource[:rhsm_cacert].nil?
     params << "--rhsm.baseurl" <<  @resource[:rhsm_baseurl] if ! @resource[:rhsm_baseurl].nil?
 
     return params

--- a/lib/puppet/type/rhsm_register.rb
+++ b/lib/puppet/type/rhsm_register.rb
@@ -38,8 +38,16 @@ Puppet::Type.newtype(:rhsm_register) do
     defaultto false
   end
 
+  newparam(:server_prefix) do
+    desc "The prefix used for registration queries sent to the rhsm server"
+  end
+
   newparam(:rhsm_baseurl) do
     desc "Specify a CDN baseurl to use"
+  end
+
+  newparam(:rhsm_cacert) do
+    desc "CA certificate for the repository and the issued client certs"
   end
 
   newparam(:username) do
@@ -61,7 +69,7 @@ Puppet::Type.newtype(:rhsm_register) do
 
   newparam(:force, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc "Should the registration be forced. Use this option with caution,
-	  setting it true will cause the subscription-manager command to be run
+          setting it true will cause the subscription-manager command to be run
           every time runs."
     defaultto false
   end


### PR DESCRIPTION
We use this to register boxes with our Katello server, dropping the CA certificate in with puppet prior to subscription_manager's run.
