### PR TITLE
Missing written_overrides.json causes false positives for rhsm_repo

### DIFF
--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -16,19 +16,18 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
   end
 
   def self.instances
-    repo_file = '/var/lib/rhsm/cache/written_overrides.json'
+    repo_file = '/var/lib/rhsm/cache/content_overrides.json'
     repo_instances = Array.new
     if File.exists?(repo_file)
       repos = JSON.parse(File.open(repo_file).read)
-      repos.each do |key, values|
-	debug("Checking enabled for #{key}")
-       if repos[key]['enabled'] == '1'
-	  debug("#{key} enabled")
-	  repo_instances.push(new(:name => key, :ensure => :present))
-	end
-     end
-      return repo_instances
+      repos.each do |repo|
+        if repo.has_key?('value') && repo['value'] == '1'
+          n = repo['contentLabel']
+          repo_instances.push( new( :name => n, :ensure => :present ))
+        end
+      end
     end
+    return repo_instances  
   end
 
   def self.prefetch(resources)
@@ -41,8 +40,6 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
   end
 
   def exists?
-    debug("Verifying whether repo is enabled")
-
     @property_hash[:ensure] == :present
   end
 


### PR DESCRIPTION
In some cases, /var/lib/rhsm/cache/written_overrides.json doesn't exist, and rhsm_repo gets into a loop identifying existing repos on the system.  /var/lib/rhsm/cache/content_overrides.json seems to be a more stable source of info.
